### PR TITLE
Don't log to syslog per default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ commands are exposed as subcommands. It automatically finds the
 appropriate subcommand.
 
 
-On Linux, any `mara` command will automatically log to `syslog`.
-
 ## Contributed MARA_* functionality in this package
 
 * A click command which iterates the known set config items 


### PR DESCRIPTION
In docker containers this lead to lot's of errors. So now it has to
be enabled for now.