### PR TITLE
skip 'mara-' prefix from multi commands

### DIFF
--- a/mara_cli/cli.py
+++ b/mara_cli/cli.py
@@ -63,8 +63,10 @@ def setup_commandline_commands():
             package = command.__dict__['callback'].__module__.rpartition('.')[0]
             # Give a package a chance to put all their commands as subcommands of the main package name.
             # For that to work we have to make sure we do not add multiple commands with the same name
-            if isinstance(command, click.Group):
+            if isinstance(command, click.MultiCommand):
                 name = command.name
+                if name.startswith('mara-'):
+                    name = name[5:]
             else:
                 name = package + '.' + command.name
             if name in known_names:


### PR DESCRIPTION
this is to skip the `mara-` prefix of the command groups in the mara modules. See also https://github.com/mara/mara-db/pull/74